### PR TITLE
[Podspec] Update version to 0.5.0

### DIFF
--- a/LlamaKit.podspec
+++ b/LlamaKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "LlamaKit"
-  s.version      = "0.1.0"
+  s.version      = "0.5.0"
   s.summary      = "Collection of must-have functional Swift tools."
   s.description  = "Collection of must-have functional tools. Trying to be as lightweight as possible, hopefully providing a simple foundation that more advanced systems can build on. LlamaKit is very Cocoa-focused. It is designed to work with common Cocoa paradigms, use names that are understandable to Cocoa devs, integrate with Cocoa tools like GCD, and in general strive for a low-to-modest learning curve for devs familiar with ObjC and Swift rather than Haskell and ML."
   s.homepage     = "https://github.com/LlamaKit/LlamaKit"
@@ -9,6 +9,6 @@ Pod::Spec.new do |s|
   s.social_media_url   = "http://twitter.com/cocoaphony"
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.10"
-  s.source       = { :git => "https://github.com/LlamaKit/LlamaKit.git", :tag => "v0.1.0" }
+  s.source       = { :git => "https://github.com/LlamaKit/LlamaKit.git", :tag => "v#{s.version}" }
   s.source_files  = "LlamaKit/*.swift"
 end


### PR DESCRIPTION
Master seems to be 0.5.0 and not 0.1.0.

Is there any reason this isn't available in the master spec repository for CocoaPods?