### PR TITLE
Add definitions for == and !=

### DIFF
--- a/LlamaKit/Result.swift
+++ b/LlamaKit/Result.swift
@@ -137,6 +137,20 @@ public func ??<T,E>(result: Result<T,E>, defaultValue: @autoclosure () -> T) -> 
   }
 }
 
+/// Equatable
+/// Equality for Result is defined by the equality of the contained types
+public func ==<T, E where T: Equatable, E: Equatable>(lhs: Result<T, E>, rhs: Result<T, E>) -> Bool {
+    switch (lhs, rhs) {
+    case let (.Success(l), .Success(r)): return l.unbox == r.unbox
+    case let (.Failure(l), .Failure(r)): return l.unbox == r.unbox
+    default: return false
+    }
+}
+
+public func !=<T, E where T: Equatable, E: Equatable>(lhs: Result<T, E>, rhs: Result<T, E>) -> Bool {
+  return !(lhs == rhs)
+}
+
 /// Due to current swift limitations, we have to include this Box in Result.
 /// Swift cannot handle an enum with multiple associated data (A, NSError) where one is of unknown size (A)
 final public class Box<T> {

--- a/LlamaKitTests/ResultTests.swift
+++ b/LlamaKitTests/ResultTests.swift
@@ -148,4 +148,32 @@ class ResultTests: XCTestCase {
     XCTAssertFalse(result.isSuccess)
     XCTAssert(result.description.hasPrefix("Failure: Error Domain=domain Code=1 "))
   }
+
+  func testSuccessEquality() {
+    let result: Result<String, NSError> = success("result")
+    let otherResult: Result<String, NSError> = success("result")
+
+    XCTAssert(result == otherResult)
+  }
+
+  func testFailureEquality() {
+    let result: Result<String, NSError> = failure(err)
+    let otherResult: Result<String, NSError> = failure(err)
+
+    XCTAssert(result == otherResult)
+  }
+
+  func testSuccessInequality() {
+    let result: Result<String, NSError> = success("result")
+    let otherResult: Result<String, NSError> = success("different result")
+
+    XCTAssert(result != otherResult)
+  }
+
+  func testFailureInequality() {
+    let result: Result<String, NSError> = failure(err)
+    let otherResult: Result<String, NSError> = failure(err2)
+
+    XCTAssert(result != otherResult)
+  }
 }


### PR DESCRIPTION
For `Result` types, equality should be defined based on the equality of the contained types. This adds the logic for `==` (flipped for `!=`) to allow you to compare two instances of `Result`.

I saw a mention from @rnapier [on the mailing list](https://groups.google.com/forum/#!msg/llamakit/cQdv2i2A4Zw/Wghdic1fbeUJ) about removing this operator implementation, but I don't fully understand why. I think this is a totally reasonable thing to have, and I was actually a little surprised when it didn't exist.