### PR TITLE
use XCTAssertNil when testing against nil

### DIFF
--- a/LlamaKitTests/ResultTests.swift
+++ b/LlamaKitTests/ResultTests.swift
@@ -31,7 +31,7 @@ class ResultTests: XCTestCase {
 
   func testSuccessReturnsNoError() {
     let s: Result<Int,NSError> = success(42)
-    XCTAssert(s.error == nil)
+    XCTAssertNil(s.error)
   }
 
   func testFailureReturnsError() {


### PR DESCRIPTION
I think we should prefer `XCTestAssert*` assertions over `XCTestAssert` whenever possible and especially when testing agains nil. (Test suites uses `XCTAssertNil` everywhere else)