### PR TITLE
Result: Support Swift 1.2

### DIFF
--- a/LlamaKit/Result.swift
+++ b/LlamaKit/Result.swift
@@ -128,7 +128,7 @@ extension Result: Printable {
 /// Failure coalescing
 ///    .Success(Box(42)) ?? 0 ==> 42
 ///    .Failure(NSError()) ?? 0 ==> 0
-public func ??<T,E>(result: Result<T,E>, defaultValue: @autoclosure () -> T) -> T {
+public func ??<T,E>(result: Result<T,E>, @autoclosure defaultValue:  () -> T) -> T {
   switch result {
   case .Success(let value):
     return value.unbox

--- a/LlamaKitTests/ResultTests.swift
+++ b/LlamaKitTests/ResultTests.swift
@@ -59,13 +59,13 @@ class ResultTests: XCTestCase {
 
   func testMapSuccessNewType() {
     let x: Result<String, NSError> = success("abcd")
-    let y = x.map { countElements($0) }
+    let y = x.map { count($0) }
     XCTAssertEqual(y.value!, 4)
   }
 
   func testMapFailureNewType() {
     let x: Result<String, NSError> = failure(self.err)
-    let y = x.map { countElements($0) }
+    let y = x.map { count($0) }
     XCTAssertEqual(y.error!, self.err)
   }
 


### PR DESCRIPTION
Swift 1.2 makes `@autoclosure` an attribute of the parameter
attribute, not its declaration. Make that change to support Swift 1.2
(breaking support for Swift 1.1).

The tests **do not** pass with this commit: `testTryTFailure` fails.