### PR TITLE
Swift 1.2 compatibility

### DIFF
--- a/LlamaKit/Result.swift
+++ b/LlamaKit/Result.swift
@@ -128,7 +128,7 @@ extension Result: Printable {
 /// Failure coalescing
 ///    .Success(Box(42)) ?? 0 ==> 42
 ///    .Failure(NSError()) ?? 0 ==> 0
-public func ??<T,E>(result: Result<T,E>, defaultValue: @autoclosure () -> T) -> T {
+public func ??<T,E>(result: Result<T,E>, @autoclosure defaultValue:  () -> T) -> T {
   switch result {
   case .Success(let value):
     return value.unbox


### PR DESCRIPTION
Small syntax change per Swift 1.2 changes to `@autoclosure` attribute.