### PR TITLE
Support Swift 1.2

### DIFF
--- a/LlamaKit/Result.swift
+++ b/LlamaKit/Result.swift
@@ -128,7 +128,7 @@ extension Result: Printable {
 /// Failure coalescing
 ///    .Success(Box(42)) ?? 0 ==> 42
 ///    .Failure(NSError()) ?? 0 ==> 0
-public func ??<T,E>(result: Result<T,E>, defaultValue: @autoclosure () -> T) -> T {
+public func ??<T,E>(result: Result<T,E>, @autoclosure defaultValue:  () -> T) -> T {
   switch result {
   case .Success(let value):
     return value.unbox

--- a/LlamaKitTests/ResultTests.swift
+++ b/LlamaKitTests/ResultTests.swift
@@ -59,13 +59,13 @@ class ResultTests: XCTestCase {
 
   func testMapSuccessNewType() {
     let x: Result<String, NSError> = success("abcd")
-    let y = x.map { countElements($0) }
+    let y = x.map { count($0) }
     XCTAssertEqual(y.value!, 4)
   }
 
   func testMapFailureNewType() {
     let x: Result<String, NSError> = failure(self.err)
-    let y = x.map { countElements($0) }
+    let y = x.map { count($0) }
     XCTAssertEqual(y.error!, self.err)
   }
 
@@ -134,8 +134,8 @@ class ResultTests: XCTestCase {
   }
 
   func testTryTFailure() {
-    let result = try(makeTryFunction(nil as Int?, false))
-    XCTAssertEqual(result ?? 43, 43)
+    let result = try(makeTryFunction(nil as String?, false))
+    XCTAssertEqual(result ?? "abc", "abc")
     XCTAssert(result.description.hasPrefix("Failure: Error Domain=domain Code=1 "))
   }
 


### PR DESCRIPTION
Alternative take on #24. I went for replacing the `Int?` in `testTryTFailure` with `String?` which doesn't produce that odd integer coercion. No hard feelings if you'd rather make the changes there. :ok_hand: 