### PR TITLE
Allow importing projects to target iOS 8.0 with Swift 1.2.

### DIFF
--- a/LlamaKit.podspec
+++ b/LlamaKit.podspec
@@ -1,13 +1,13 @@
 Pod::Spec.new do |s|
   s.name         = "LlamaKit"
-  s.version      = "0.6.0"
+  s.version      = "0.6.1"
   s.summary      = "Collection of must-have functional Swift tools."
   s.description  = "Collection of must-have functional tools. Trying to be as lightweight as possible, hopefully providing a simple foundation that more advanced systems can build on. LlamaKit is very Cocoa-focused. It is designed to work with common Cocoa paradigms, use names that are understandable to Cocoa devs, integrate with Cocoa tools like GCD, and in general strive for a low-to-modest learning curve for devs familiar with ObjC and Swift rather than Haskell and ML."
   s.homepage     = "https://github.com/LlamaKit/LlamaKit"
   s.license      = "MIT"
   s.author             = { "Rob Napier" => "robnapier@gmail.com" }
   s.social_media_url   = "https://twitter.com/cocoaphony"
-  s.ios.deployment_target = "8.3"
+  s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.10"
   s.source       = { :git => "https://github.com/LlamaKit/LlamaKit.git", :tag => "v#{s.version}" }
   s.source_files  = "LlamaKit/*.swift"


### PR DESCRIPTION
Trying to "pod install" LlamaKit 0.6.0 in an iOS 8.0 project does not succeed. It should be OK to use Swift 1.2 in Xcode 6.3 with the iOS 8.0 SDK.
