### PR TITLE
Result: Fix trailing closure warning for try()

### DIFF
--- a/LlamaKit/Result.swift
+++ b/LlamaKit/Result.swift
@@ -54,12 +54,12 @@ public func failure<T,E>(error: E) -> Result<T,E> {
 /// Construct a `Result` using a block which receives an error parameter.
 /// Expected to return non-nil for success.
 
-public func try<T>(f: NSErrorPointer -> T?, file: String = __FILE__, line: Int = __LINE__) -> Result<T,NSError> {
+public func try<T>(file: String = __FILE__, line: Int = __LINE__, f: NSErrorPointer -> T?) -> Result<T,NSError> {
   var error: NSError?
   return f(&error).map(success) ?? failure(error ?? defaultError(file: file, line: line))
 }
 
-public func try(f: NSErrorPointer -> Bool, file: String = __FILE__, line: Int = __LINE__) -> Result<(),NSError> {
+public func try(file: String = __FILE__, line: Int = __LINE__, f: NSErrorPointer -> Bool) -> Result<(),NSError> {
   var error: NSError?
   return f(&error) ? success(()) : failure(error ?? defaultError(file: file, line: line))
 }


### PR DESCRIPTION
When compiling LlamaKit using Xcode 6.3β2 (6D532l), the try functions
generate the following warning: "Closure parameter prior to parameters
with default arguments will not be treated as a trailing closure."

Move the closure argument after the arguments that take defaults, fixing
the warning.