### PR TITLE
Added block based versions of 'map' and 'flatMap'

### DIFF
--- a/LlamaKit/Result.swift
+++ b/LlamaKit/Result.swift
@@ -112,6 +112,31 @@ public enum Result<T,E> {
     case Failure(let error): return .Failure(error)
     }
   }
+  
+  /// Block-based version of 'map'
+  /// Calls completion after applying a transformation to a successful value.
+  /// Mapping a failure calls the completion with a new failure without evaluating the transform
+  public func map<U>(transform: (T, U -> Void) -> Void, completion: (Result<U,E>) -> Void) {
+    switch self {
+    case Success(let box):
+      transform(box.unbox, { r in completion(.Success(Box(r))) })
+    case Failure(let err):
+      completion(.Failure(err))
+    }
+  }
+
+  /// Block-based version of 'flatMap'
+  /// Calls completion after applying a transformation (that itself calls a completion
+  /// expecting a result) to a successful value.
+  /// Mapping a failure calls the completion with a new failure without evaluating the transform
+  public func flatMap<U>(transform: (T, (Result<U,E>) -> Void) -> Void, completion: (Result<U,E>) -> Void) {
+    switch self {
+    case Success(let box):
+      transform(box.unbox, completion)
+    case Failure(let err):
+      completion(.Failure(err))
+    }
+  }
 }
 
 extension Result: Printable {

--- a/LlamaKit/Result.swift
+++ b/LlamaKit/Result.swift
@@ -64,6 +64,17 @@ public func try(f: NSErrorPointer -> Bool, file: String = __FILE__, line: Int = 
   return f(&error) ? success(()) : failure(error ?? defaultError(file: file, line: line))
 }
 
+/// Convenience method: Constructs a `Result` trying to unwrap an Optional 
+/// Returns a failure with the supplied error in case the Optional is `nil`
+public func valueOrError<T,E>(value: T?, error: E) -> Result<T, E> {
+  if let value = value {
+    return success(value)
+  }
+  else {
+    return failure(error)
+  }
+}
+
 /// Container for a successful value (T) or a failure with an E
 public enum Result<T,E> {
   case Success(Box<T>)

--- a/LlamaKitTests/ResultTests.swift
+++ b/LlamaKitTests/ResultTests.swift
@@ -160,7 +160,19 @@ class ResultTests: XCTestCase {
       XCTAssertEqual(r.error!, self.err2)
     }
   }
+  
+  func testValueOrNilSuccess() {
+    let value: Int? = 42
+    let x = valueOrError(value, "Value is nil")
+    XCTAssertEqual(x.value!, 42)
+  }
 
+  func testValueOrNilFailure() {
+    let value: Int? = nil
+    let x = valueOrError(value, "Value is nil")
+    XCTAssertEqual(x.error!, "Value is nil")
+  }
+  
   func testDescriptionSuccess() {
     let x: Result<Int, NSError> = success(42)
     XCTAssertEqual(x.description, "Success: 42")

--- a/LlamaKitTests/ResultTests.swift
+++ b/LlamaKitTests/ResultTests.swift
@@ -76,7 +76,7 @@ class ResultTests: XCTestCase {
   func doubleFailure(x: Int) -> Result<Int, NSError> {
     return failure(self.err)
   }
-
+  
   func testFlatMapSuccessSuccess() {
     let x: Result<Int, NSError> = success(42)
     let y = x.flatMap(doubleSuccess)
@@ -99,6 +99,66 @@ class ResultTests: XCTestCase {
     let x: Result<Int, NSError> = failure(self.err2)
     let y = x.flatMap(doubleFailure)
     XCTAssertEqual(y.error!, self.err2)
+  }
+  
+  func intToString(input: Int, completion: String -> Void) {
+    let stringValue = "\(input)"
+    completion(stringValue)
+  }
+  
+  func testBlockBasedMapSuccessNewType() {
+    let x: Result<Int, NSError> = success(42)
+    x.map (self.intToString) { r in
+      XCTAssertEqual(r.value!, "42")
+    }
+  }
+  
+  func testBlockBasedMapFailureNewType() {
+    let x: Result<Int, NSError> = failure(self.err)
+    x.map (self.intToString) { r in
+      XCTAssertEqual(r.error!, self.err)
+    }
+  }
+  
+  func stringToInt(input: String, completion: (Result<Int, NSError>) -> Void) {
+    if let intValue = input.toInt() {
+      completion(success(intValue))
+    }
+    else {
+      completion(failure(self.err))
+    }
+  }
+  
+  func stringToFailure(input: String, completion: (Result<Int, NSError>) -> Void) {
+    completion(failure(self.err))
+  }
+  
+  func testBlockBasedFlatMapSuccessSuccess() {
+    let x: Result<String, NSError> = success("42")
+    x.flatMap(self.stringToInt) { r in
+      XCTAssertEqual(r.value!, 42)
+    }
+  }
+  
+  func testBlockBasedFlatMapSuccessFailure() {
+    let x: Result<String, NSError> = success("abc")
+    x.flatMap(self.stringToInt) { r in
+      XCTAssertEqual(r.error!, self.err)
+    }
+  }
+  
+  func testBlockBasedFlatMapFailureSuccess() {
+    let x: Result<String, NSError> = failure(self.err2)
+    x.flatMap(self.stringToInt) { r in
+      XCTAssertEqual(r.error!, self.err2)
+    }
+  }
+  
+  func testBlockBasedFlatMapFailureFailure() {
+    let x: Result<String, NSError> = failure(self.err2)
+    x.flatMap(self.stringToFailure) { r in
+      XCTAssertEqual(r.error!, self.err2)
+    }
   }
 
   func testDescriptionSuccess() {


### PR DESCRIPTION
Hi there,
I love the idea behind the Result enum in LlamaKit! I am currently writing a Swift wrapper for a web API, and naturally I have a lot of asynchronous stuff.
So I figured why not have block based versions of map and flatMap?
It works similar to the 'return'-based versions, but are used like:
   
<pre>
  // Method that already calls a block with a Result (needs 'flat' mapping)
  func stringToInt(input: String, completion: (Result<Int, NSError>) -> Void) {
    if let intValue = input.toInt() {
      completion(success(intValue))
    }
    else {
      completion(failure(self.err))
    }
  }
  
  // Method that always calls a block with a value
  func intToString(input: Int, completion: String -> Void) {
    let stringValue = "\(input)"
    completion(stringValue)
  }

  // Any number of block calls may be 'chained' as follows:
  func testBlockMap() {
    let r: Result<String, NSError> = success("42")
    r.flatMap(self.stringToInt) { r in
      r.map(self.intToString) { r in
        r.flatMap(self.stringToInt) { r in
          r.map(self.intToString) { r in
            XCTAssertEqual(r.value!, "42")
          }
        }
      }
    }
  }
</pre>

Is this something you would consider adding to LlamaKit?
Sincerely,
/morten
